### PR TITLE
BUYE-536: migrate from Zemanta to Outbrain org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gracefulshutdown [![Build Status](https://travis-ci.org/Zemanta/gracefulshutdown.svg)](https://travis-ci.org/Zemanta/gracefulshutdown)
+# gracefulshutdown
 
 Providing shutdown callbacks for graceful app shutdown
 
@@ -13,16 +13,16 @@ We decided to use the same callback pattern in case of handling POSIX signals.
 ## Installation
 
 ```
-go get github.com/Zemanta/gracefulshutdown
+go get github.com/outbrain/gracefulshutdown
 ```
 
 ## Documentation
 
-`github.com/Zemanta/gracefulshutdown` documentation is available on [godoc](http://godoc.org/github.com/Zemanta/gracefulshutdown).
+`github.com/outbrain/gracefulshutdown` documentation is available on [godoc](http://godoc.org/github.com/outbrain/gracefulshutdown).
 
 Both `ShutdownManagers` are also documented:
-- [`PosixSignalManager`](http://godoc.org/github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal)
-- [`AwsManager`](http://godoc.org/github.com/Zemanta/gracefulshutdown/shutdownmanagers/awsmanager)
+- [`PosixSignalManager`](http://godoc.org/github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal)
+- [`AwsManager`](http://godoc.org/github.com/outbrain/gracefulshutdown/shutdownmanagers/awsmanager)
 
 
 ## Example - AWS Autoscale, Scale-in Event
@@ -38,9 +38,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Zemanta/gracefulshutdown"
-	"github.com/Zemanta/gracefulshutdown/shutdownmanagers/awsmanager"
-	"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+	"github.com/outbrain/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown/shutdownmanagers/awsmanager"
+	"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 )
 
 func main() {
@@ -95,8 +95,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Zemanta/gracefulshutdown"
-	"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+	"github.com/outbrain/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 )
 
 func main() {
@@ -137,8 +137,8 @@ import (
 	"time"
 	"errors"
 
-	"github.com/Zemanta/gracefulshutdown"
-	"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+	"github.com/outbrain/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 )
 
 func main() {

--- a/gracefulshutdown.go
+++ b/gracefulshutdown.go
@@ -1,26 +1,26 @@
 /*
-
 Providing shutdown callbacks for graceful app shutdown
 
-Installation
+# Installation
 
 To install run:
 
-	go get github.com/Zemanta/gracefulshutdown
+	go get github.com/outbrain/gracefulshutdown
 
-Example - posix signals
+# Example - posix signals
 
 Graceful shutdown will listen for posix SIGINT and SIGTERM signals.
 When they are received it will run all callbacks in separate go routines.
 When callbacks return, the application will exit with os.Exit(0)
+
 	package main
 
 	import (
 		"fmt"
 		"time"
 
-		"github.com/Zemanta/gracefulshutdown"
-		"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+		"github.com/outbrain/gracefulshutdown"
+		"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 	)
 
 	func main() {
@@ -48,7 +48,7 @@ When callbacks return, the application will exit with os.Exit(0)
 		time.Sleep(time.Hour)
 	}
 
-Example - posix signals with error handler
+# Example - posix signals with error handler
 
 The same as above, except now we set an ErrorHandler that prints the
 error returned from ShutdownCallback.
@@ -60,8 +60,8 @@ error returned from ShutdownCallback.
 		"time"
 		"errors"
 
-		"github.com/Zemanta/gracefulshutdown"
-		"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+		"github.com/outbrain/gracefulshutdown"
+		"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 	)
 
 	func main() {
@@ -94,7 +94,7 @@ error returned from ShutdownCallback.
 		time.Sleep(time.Hour)
 	}
 
-Example - aws
+# Example - aws
 
 Graceful shutdown will listen for SQS messages on "example-sqs-queue".
 If a termination message has current EC2 instance id,
@@ -105,15 +105,16 @@ When callbacks return, the application will call aws api CompleteLifecycleAction
 The callback will delay only if shutdown was initiated by awsmanager.
 If the message does not have current instance id, it will forward the
 message to correct instance via http on port 7999.
+
 	package main
 
 	import (
 		"fmt"
 		"time"
 
-		"github.com/Zemanta/gracefulshutdown"
-		"github.com/Zemanta/gracefulshutdown/shutdownmanagers/awsmanager"
-		"github.com/Zemanta/gracefulshutdown/shutdownmanagers/posixsignal"
+		"github.com/outbrain/gracefulshutdown"
+		"github.com/outbrain/gracefulshutdown/shutdownmanagers/awsmanager"
+		"github.com/outbrain/gracefulshutdown/shutdownmanagers/posixsignal"
 	)
 
 	func main() {
@@ -251,6 +252,7 @@ func (gs *GracefulShutdown) AddShutdownManager(manager ShutdownManager) {
 //
 // You can provide anything that implements ShutdownCallback interface,
 // or you can supply a function like this:
+//
 //	AddShutdownCallback(gracefulshutdown.ShutdownFunc(func() error {
 //		// callback code
 //		return nil
@@ -264,6 +266,7 @@ func (gs *GracefulShutdown) AddShutdownCallback(shutdownCallback ShutdownCallbac
 //
 // You can provide anything that implements ErrorHandler interface,
 // or you can supply a function like this:
+//
 //	SetErrorHandler(gracefulshutdown.ErrorFunc(func (err error) {
 //		// handle error
 //	}))

--- a/shutdownmanagers/awsmanager/aws.go
+++ b/shutdownmanagers/awsmanager/aws.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Zemanta/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/sqs"

--- a/shutdownmanagers/awsmanager/aws_test.go
+++ b/shutdownmanagers/awsmanager/aws_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Zemanta/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown"
 
 	"github.com/aws/aws-sdk-go/service/sqs"
 )

--- a/shutdownmanagers/posixsignal/posixsignal.go
+++ b/shutdownmanagers/posixsignal/posixsignal.go
@@ -10,7 +10,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/Zemanta/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown"
 )
 
 const Name = "PosixSignalManager"

--- a/shutdownmanagers/posixsignal/posixsignal_test.go
+++ b/shutdownmanagers/posixsignal/posixsignal_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Zemanta/gracefulshutdown"
+	"github.com/outbrain/gracefulshutdown"
 )
 
 type startShutdownFunc func(sm gracefulshutdown.ShutdownManager)


### PR DESCRIPTION
Zemanta org in Github is being deprecated in favor of Outbrain.

_https://teads.atlassian.net/browse/BUYE-536_